### PR TITLE
(Presets): Update hardware.jsonc

### DIFF
--- a/presets/hardware.jsonc
+++ b/presets/hardware.jsonc
@@ -1,25 +1,37 @@
 {
     "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
-    "logo": {
-        "type": "builtin",
-        "source": "arch"
-    },
     "modules": [
-        "host",
-        "display",
+	    {
+		    "type": "host",
+			"format": "{?2}{2}{?}{?5} ({5}){?}"
+		},
+		"chassis",
+		{
+		    "type": "board",
+			"format": "{?1}{1}{?}{?2} ({2}){?}"
+		},
         "cpu",
-        "gpu",
         {
             "type": "memory",
             "format": "{?2}{2}{?}"
         },
-        {
-            "type": "disk",
-            "format": "{?2}{2}{?}"
-        },
+		"physicaldisk",
+		"gpu",
+	    "display",
+		"monitor",
+		{
+		    "type": "wifi",
+			"format": "{?1}{1}{?}{?6} - {6}{?}"
+		},
+	    {
+		    "type": "sound",
+			"format": "{?2}{2}{?}"
+		},
+		"camera",
         {
             "type": "battery",
-            "format": "{?1}{1} {?}{?2}{2} {?}{?3}({3}){?}"
-        }
+            "format": "{?1}{1}{?}{?2} {2}{?}{?3} ({3}){?}"
+        },
+		"poweradapter"
     ]
 }


### PR DESCRIPTION
Update hardware.jsonc preset, fix logo being forced to Arch, add more hardware information.
Feel free to close or to propose more changes.